### PR TITLE
Fer que cron-parse-tables.py admeti un offset arbitrari

### DIFF
--- a/TableParser.py
+++ b/TableParser.py
@@ -52,9 +52,11 @@ class TableParser:
 
                     timeSplit = hora.split(':')
 
-                    begins = datetime(year, month, day, int(timeSplit[0]), int(timeSplit[1]))
-                    begins = pytz.timezone(self.TIMEZONE).localize(begins)
-                    ends = begins + timedelta(minutes=durada)
+                    beginsDateTime = datetime(year, month, day, int(timeSplit[0]), int(timeSplit[1]))
+                    beginsDateTime = pytz.timezone(self.TIMEZONE).localize(beginsDateTime)
+                    begins = int(beginsDateTime.timestamp())
+                    endsDateTime = beginsDateTime + timedelta(minutes=durada)
+                    ends = int(endsDateTime.timestamp())
 
                     print(("Afegint " if db != None else "") + assignaturaRaw
                             + ", " + hora

--- a/cron-parse-tables.py
+++ b/cron-parse-tables.py
@@ -2,30 +2,60 @@ import pyodbc
 import configparser
 from TableParser import TableParser
 import datetime
+import sys
+import getopt
 
-config = configparser.ConfigParser()
-config.read('config.ini')
+def main(argv):
+    config = configparser.ConfigParser()
+    config.read('config.ini')
 
-db_host = config['db']['host']
-db_database = config['db']['database']
-db_user = config['db']['user']
-db_password = config['db']['password']
+    db_host = config['db']['host']
+    db_database = config['db']['database']
+    db_user = config['db']['user']
+    db_password = config['db']['password']
 
-connection_string = (
-    'DRIVER=MySQL ODBC 8.0 ANSI Driver;'
-    'SERVER=' + db_host + ';'
-    'DATABASE=' + db_database + ';'
-    'UID=' + db_user + ';'
-    'PWD=' + db_password + ';'
-    'charset=utf8mb4;'
-)
+    connection_string = (
+        'DRIVER=MySQL ODBC 8.0 ANSI Driver;'
+        'SERVER=' + db_host + ';'
+        'DATABASE=' + db_database + ';'
+        'UID=' + db_user + ';'
+        'PWD=' + db_password + ';'
+        'charset=utf8mb4;'
+    )
 
-db = pyodbc.connect(connection_string)
-db.setdecoding(pyodbc.SQL_WCHAR, encoding='utf-8')
-db.setencoding(encoding='utf-8')
+    db = pyodbc.connect(connection_string)
+    db.setdecoding(pyodbc.SQL_WCHAR, encoding='utf-8')
+    db.setencoding(encoding='utf-8')
 
-tomorrow = datetime.date.today() + datetime.timedelta(days=1)
+    try:
+        opts, args = getopt.getopt(argv, 'o:', ['offset='])
+    except getopt.GetoptError:
+        print('Usage: python cron-parse-tables.py -o <offset_in_days>')
+        print('    The offset is the day relative to today that wants to be')
+        print('    parsed. For instance, -1 is yesterday and 1 is tomorrow.')
+        sys.exit(2)
 
-parser = TableParser('https://fme-intranet.upc.edu/appsext/mrbs/web/day.php')
-for area in [2, 6]:
-    parser.parse(tomorrow.year, tomorrow.month, tomorrow.day, area, db)
+    offset = 1
+    for opt, arg in opts:
+        if opt in ('-o', '--offset'):
+            offset = arg
+        else:
+            print('Parameter \'' + opt + '\' not recognized.')
+            print('')
+            print('Run python cron-parse-tables.py to get help on how to use')
+            print('this script.')
+
+    offset = int(offset)
+
+    print('Parsejant les classes ' +
+        (('de fa ' if offset < 0 else 'de dins de ') +
+        str(abs(offset)) + (' dia' if abs(offset) == 1 else ' dies') if offset != 0 else 'd\'avui'))
+
+    tomorrow = datetime.date.today() + datetime.timedelta(days=offset)
+
+    parser = TableParser('https://fme-intranet.upc.edu/appsext/mrbs/web/day.php')
+    for area in [2, 6]:
+        parser.parse(tomorrow.year, tomorrow.month, tomorrow.day, area, db)
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
Ara es pot cridar l'script per parsejear les taules per un dia en
concret, mitjançant 'python3 cron-parse-tables.py --offset=<offset>',
on '<offset>' és el nombre del dia relatiu a avui (per exemple, ahir
seria '-1' i demà '1').

A més, s'ha canviat la classe TableParser perquè en inserir les classes
a la BD introdueixi les dates com UNIX timestamps i no com a dates en
si, ja que s'ha canviat això al backend.